### PR TITLE
Archive::Unzip::Burst::unzip result is ignored and _extract_inc does always the slow way, too

### DIFF
--- a/lib/PAR.pm
+++ b/lib/PAR.pm
@@ -704,7 +704,6 @@ sub _extract_inc {
             require Archive::Unzip::Burst;
             Archive::Unzip::Burst::unzip($file_or_azip_handle, $inc)
               and die "Could not unzip '$file_or_azip_handle' into '$inc'. Error: $!";
-              die;
           };
 
           # This means the fast module is there, but didn't work.


### PR DESCRIPTION
By dying here we set `$@` and the slow unzipper sees `$@` set to `Died at .../PAR.pm line 707.` and decides to do the slow unpack, too - we end up by spending time doing both fast and slow unzips. Not what was intended.

Seems to be introduced in commit 657a1c4c79860cbc908ab1f00599402b93267185, but looks to me more like a typo then an intended change.