### PR TITLE
Quote t/gen-hello-par.pl for Windows

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -46,7 +46,7 @@ sub MY::postamble {
     return <<'...';
 pure_all :: t/hello.par
 t/hello.par:
-	$(PERL) t/gen-hello-par.pl
+	$(PERL) "t/gen-hello-par.pl"
 ...
 }
 


### PR DESCRIPTION
When installing PAR on Windows (using cpanm in this case), an error
occurs and prevents installing:

cp lib/PAR/Environment.pod blib\lib\PAR\Environment.pod
        "D:\path\to\perl\5.32.1\AMD64\bin\perl.exe" t/gen-hello-par.pl
Can't open perl script "t": Permission denied
NMAKE : fatal error U1077: 'D:\path\to\perl\5.32.1\AMD64\bin\perl.exe' : return code '0xd'
Stop.
FAIL
! Installing PAR failed. See D:\path\to\build.log for details. Retry with --force to force install it.

Quoting the "t/gen-hello-par.pl" path/file seems to resolve the problem.