### PR TITLE
declare %FullCache as a package global

### DIFF
--- a/lib/PAR/Heavy.pm
+++ b/lib/PAR/Heavy.pm
@@ -29,7 +29,7 @@ my $dl_debug = $ENV{PERL_DL_DEBUG} || 0;
 
 my ($bootstrap, $dl_findfile);  # Caches for code references
 my ($cache_key);                # The current file to find
-my %FullCache;
+our %FullCache;
 my $is_insensitive_fs = (
     -s $0
         and (-s lc($0) || -1) == (-s uc($0) || -1)


### PR DESCRIPTION
Otherwise it is not populated and dynamic libs
cannot be located.

PR #9 changed the declaration to a package lexical.
Unfortunately this did not properly handle 
dynamic libs because the hash was no longer populated.  

It seems this functionality is not exercised by the tests.  

An alternative is to revert #9 in the event there might be 
other untested edge cases.  
